### PR TITLE
Fix for issue #8 : Syntax highlighting for code blocks

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,3 +1,6 @@
 // custom typefaces
 import 'typeface-montserrat'
 import 'typeface-merriweather'
+
+// syntax highlighting template
+require("prismjs/themes/prism-okaidia.css");

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -39,7 +39,18 @@ module.exports = {
               wrapperStyle: `margin-bottom: 1.0725rem`,
             },
           },
-          `gatsby-remark-prismjs`,
+          {
+            resolve: `gatsby-remark-prismjs`,
+            options: {
+              classPrefix: "language-",
+              inlineCodeMarker: null,
+              aliases: {
+                js: "javascript"
+              },
+              showLineNumbers: false,
+              noInlineHighlight: true,
+            },
+          },
           `gatsby-remark-copy-linked-files`,
           `gatsby-remark-smartypants`,
         ],


### PR DESCRIPTION
Hey, cool idea using markdown for a blog.
I wanted to test how the bounty system works. I hope this does what you wanted.

I set a dark prism theme as global default. You can copy the template and make your own if you don't find a good one in `prismjs/themes/` and want to change some colours. Line numbers are deactivated by default. For more customisation see [the Readme.md](https://github.com/chasm/gatsby-remark-prismjs/blob/d637057f2e981d56acf7975d628786ef21488507/README.md)

Commit msg:
 * gatsby-browser: added prism stylesheet file
* gatsby-config: added options for prismjs, alias for javascript

Preview:
![grafik](https://user-images.githubusercontent.com/8905319/58790292-608cdb80-85f0-11e9-98c7-01a05a830a0d.png)